### PR TITLE
Added auth_key to connector config as a field

### DIFF
--- a/urlhaus/info.json
+++ b/urlhaus/info.json
@@ -18,6 +18,16 @@
         "editable": true,
         "description": "Specify the server URL to which you will connect and perform the automated operations.",
         "value": "https://urlhaus-api.abuse.ch"
+      },
+      {
+        "title": "Auth Key",
+        "type": "password",
+        "name": "auth_key",
+        "required": true,
+        "visible": true,
+        "editable": true,
+        "description": "Specify the Auth-Key obtained from abuse.ch authentication portal to authenticate API requests.",
+        "value": ""
       }
     ]
   },

--- a/urlhaus/operations.py
+++ b/urlhaus/operations.py
@@ -21,6 +21,7 @@ logger = get_logger('urlhaus')
 class urlhaus(object):
     def __init__(self, config):
         self.server_url = config.get('server_url')
+        self.auth_key = config.get("auth_key")
         if not self.server_url.startswith('https://'):
             self.server_url = 'https://' + self.server_url
         if not self.server_url.endswith('/'):
@@ -29,6 +30,9 @@ class urlhaus(object):
     def make_request(self, endpoint=None, method='GET', data=None, params=None, files=None, headers=None, timeout=None):
         try:
             url = self.server_url + endpoint
+            if headers is None:
+                headers = {}
+            headers["Auth-Key"] = self.auth_key
             response = requests.request(method, url, params=params, files=files, data=data, headers=headers,
                                         timeout=timeout)
             if response.status_code == 200:


### PR DESCRIPTION
#### Descriptions:
Fixed authentication issue with the connector. In the 1.0.0 version connector config did not have a field to paste auth key into so the connector did not work.

#### Fix:
* Added `Auth Key` to `info.json` as a extra field
* Added `auth_key` to `operations.py` for sending requests to Urlhaus. Now each request will have `auth_key` defined and the connector actions will work.
